### PR TITLE
Add Google Pay configuration fields

### DIFF
--- a/js-sdk/src/validators/googlePay.ts
+++ b/js-sdk/src/validators/googlePay.ts
@@ -69,8 +69,14 @@ export function validateGooglePayButtonWidgetOptions(
       environment: input.environment,
       merchantId: input.merchantId,
       merchantName: input.merchantName,
+      allowedCardAuthMethods: input.allowedCardAuthMethods,
+      allowedCardNetworks: input.allowedCardNetworks,
+      buttonColor: input.buttonColor,
+      buttonType: input.buttonType,
       locale: input.locale,
+      style: input.style as any,
       transactionInfo: input.transactionInfo as any,
+      disabled: input.disabled,
       onClick: input.onClick as any,
       onPaymentDataLoaded: input.onPaymentDataLoaded as any
     }


### PR DESCRIPTION
This pull request expands the set of options that can be validated for the Google Pay button widget. Several new properties are now included in the validation logic, enabling more comprehensive configuration and customization of the widget.

**Enhancements to Google Pay button widget validation:**

* Added support for validating `allowedCardAuthMethods` and `allowedCardNetworks` to specify permitted card authentication methods and networks.
* Included `buttonColor` and `buttonType` properties for customizing the appearance of the Google Pay button.
* Added validation for the `style` property, allowing more flexible styling of the widget.
* Enabled validation of the `disabled` property to control the interactive state of the button.

**Shortcut Ticket**

- [SC-79140](https://app.shortcut.com/publicsq/story/79140/add-google-pay-configuration-fields)