### PR TITLE
BT Googlepay migration

### DIFF
--- a/example-app/src/components/GooglePayElements/GooglePayElementsJs.tsx
+++ b/example-app/src/components/GooglePayElements/GooglePayElementsJs.tsx
@@ -78,7 +78,7 @@ export default function GooglePayElementsJs() {
       try {
         const tokenObj = JSON.parse(event.paymentMethodData.tokenizationData.token)
         const response = await publicsquare.googlePay.create({
-          google_payment_method_token: tokenObj
+          google_payment_data: tokenObj
         })
         if (response) {
           return response

--- a/example-app/src/components/GooglePayElements/GooglePayElementsReact.tsx
+++ b/example-app/src/components/GooglePayElements/GooglePayElementsReact.tsx
@@ -38,7 +38,7 @@ function Elements() {
       try {
         const tokenObj = JSON.parse(event.paymentMethodData.tokenizationData.token)
         const response = await psq.googlePay.create({
-          google_payment_method_token: tokenObj
+          google_payment_data: tokenObj
         })
         if (response) {
           return response

--- a/js-sdk/src/googlePay/__tests__/GooglePay.test.ts
+++ b/js-sdk/src/googlePay/__tests__/GooglePay.test.ts
@@ -16,7 +16,7 @@ jest.mock('@basis-theory/basis-theory-js', () => ({
 }))
 
 const validGooglePayCreateInput: GooglePayCreateInput = {
-  google_payment_method_token: {},
+  google_payment_data: {},
   customer_id: 'cus_123',
   billing_details: {
     address_line_1: '123 Main St',
@@ -94,7 +94,7 @@ describe('GooglePay', () => {
       })
     )
     const input = {
-      google_payment_method_token: {}
+      google_payment_data: {}
     }
     const result = await googlePay.create(input)
     expect(global.fetch).toHaveBeenCalledWith(
@@ -111,11 +111,11 @@ describe('GooglePay', () => {
     expect(result).toEqual(mockResponse)
   })
 
-  test('create() fails with invalid google_payment_method_token', async () => {
+  test('create() fails with invalid google_payment_data', async () => {
     const error = await getError<{ message: string }>(() =>
       googlePay.create({} as any)
     )
-    expect(error.message).toEqual('google_payment_method_token is required')
+    expect(error.message).toEqual('google_payment_data is required')
   })
 
   test('create() only passes validated input', async () => {
@@ -128,7 +128,7 @@ describe('GooglePay', () => {
       })
     )
     const input = {
-      google_payment_method_token: {
+      google_payment_data: {
         protocolVersion: 'ECv2',
         signature: 'abcd1234',
         intermediateSigningKey: {
@@ -149,7 +149,7 @@ describe('GooglePay', () => {
           'X-API-KEY': 'api_key'
         },
         body: JSON.stringify({
-          google_payment_method_token: {
+          google_payment_data: {
             protocolVersion: 'ECv2',
             signature: 'abcd1234',
             intermediateSigningKey: {

--- a/js-sdk/src/types/sdk/googlePay.ts
+++ b/js-sdk/src/types/sdk/googlePay.ts
@@ -31,7 +31,7 @@ export interface GooglePayButtonWidgetOptions {
 }
 
 export type GooglePayCreateInput = {
-  google_payment_method_token?: GooglePaymentMethodToken
+  google_payment_data?: GooglePaymentMethodToken
   customer_id?: string
   billing_details?: CardBillingDetails
 }

--- a/js-sdk/src/validators/googlePay.ts
+++ b/js-sdk/src/validators/googlePay.ts
@@ -8,8 +8,8 @@ import {
 export function validateCreateGooglePayInput(
   input: GooglePayCreateInput
 ): ValidatedGooglePayCreateInput {
-  if (typeof input.google_payment_method_token !== 'object') {
-    throw new Error('google_payment_method_token is required')
+  if (typeof input.google_payment_data !== 'object') {
+    throw new Error('google_payment_data is required')
   }
   if (!['string', 'undefined'].includes(typeof input.customer_id)) {
     throw new Error('customer_id must be a string if included')
@@ -19,7 +19,7 @@ export function validateCreateGooglePayInput(
   }
   return {
     validated: {
-      google_payment_method_token: input.google_payment_method_token as any,
+      google_payment_data: input.google_payment_data as any,
       customer_id: input.customer_id,
       billing_details: input.billing_details
     }


### PR DESCRIPTION
This pull request standardizes the naming of the Google Pay token field across the codebase, changing all references from `google_payment_method_token` to `google_payment_data`. This affects both the main application code and the test files, as well as the type definitions and validation logic. These changes help maintain consistency and clarity in the handling of Google Pay data.

**Google Pay token field renaming:**

* Updated the `GooglePayCreateInput` type to use `google_payment_data` instead of `google_payment_method_token` in `js-sdk/src/types/sdk/googlePay.ts`.
* Changed all usage of the token field from `google_payment_method_token` to `google_payment_data` in the Google Pay React and JS components (`example-app/src/components/GooglePayElements/GooglePayElementsReact.tsx`, `example-app/src/components/GooglePayElements/GooglePayElementsJs.tsx`). [[1]](diffhunk://#diff-ddc36524650ed8190a4a47bfd6ddacd6338b9fc05e72fab2538329dcabc5247fL41-R41) [[2]](diffhunk://#diff-daee86f935cc14ddf5e5004682192a441f6b456aa1d6ac6ee0fc4853ab50d9cfL81-R81)

**Test updates:**

* Updated all test inputs, expectations, and error messages to use `google_payment_data` instead of `google_payment_method_token` in `js-sdk/src/googlePay/__tests__/GooglePay.test.ts`. [[1]](diffhunk://#diff-c2920cf05e849244f4a8b073c9127f90a18e3ab4ff267140aa9061155b769116L19-R19) [[2]](diffhunk://#diff-c2920cf05e849244f4a8b073c9127f90a18e3ab4ff267140aa9061155b769116L97-R97) [[3]](diffhunk://#diff-c2920cf05e849244f4a8b073c9127f90a18e3ab4ff267140aa9061155b769116L114-R118) [[4]](diffhunk://#diff-c2920cf05e849244f4a8b073c9127f90a18e3ab4ff267140aa9061155b769116L131-R131) [[5]](diffhunk://#diff-c2920cf05e849244f4a8b073c9127f90a18e3ab4ff267140aa9061155b769116L152-R152)

**Validation logic update:**

* Modified the validation function to check for `google_payment_data` and updated error messages accordingly in `js-sdk/src/validators/googlePay.ts`.
* Updated the return value of the validation function to use `google_payment_data` in `js-sdk/src/validators/googlePay.ts`.

**Shortcut Link**
- [SC-79263](https://app.shortcut.com/publicsq/story/79263/bt-googlepay-migration)


