### PR TITLE
Include API key in Google Pay request headers

### DIFF
--- a/js-sdk/src/googlePay/GooglePay.ts
+++ b/js-sdk/src/googlePay/GooglePay.ts
@@ -42,7 +42,7 @@ export class PublicSquareGooglePay {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',
-          'X-API-KEY': this._publicSquare._apiKey!,
+          'X-API-KEY': this._publicSquare._apiKey ?? '',
         },
       },
     )

--- a/js-sdk/src/googlePay/GooglePay.ts
+++ b/js-sdk/src/googlePay/GooglePay.ts
@@ -42,6 +42,7 @@ export class PublicSquareGooglePay {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',
+          'X-API-KEY': this._publicSquare._apiKey!,
         },
       },
     )


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- `getGooglePayConfiguration()` was sending no credentials at all on its `GET .well-known/google-pay-configuration` request, so the backend had no way to identify which account/processor was asking. As a result the endpoint served a single static BasisTheory gateway config to every caller, which breaks Google Pay for any account whose `DefaultProcessor` is Moov (Moov requires its own `gateway`/`gatewayMerchantId`, not BasisTheory's — see [Moov's Google Pay guide](https://docs.moov.io/guides/sources/cards/google-pay/)).
- This adds the `X-API-KEY` header to that request (same header already used by `googlePay.create()`), so the backend can resolve the account and return processor-specific gateway config.
- **Depends on / must land together with** the corresponding `psq-payments-api` change that makes `.well-known/google-pay-configuration` account-aware and `[Authorize]`-protected instead of anonymous. That endpoint is moving from anonymous to requiring an API key — deploying the backend change without this SDK change (or vice versa) will break Google Pay config fetching for all accounts, not just Moov ones.

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [ ] Not Applicable
- Exercise the Google Pay button in `example-app` against staging with the corresponding `psq-payments-api` change deployed, for both a Nuvei-default and a Moov-default account, and confirm each gets the correct `gateway`/`gatewayMerchantId` back from `.well-known/google-pay-configuration`.

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [ ] Roll Forward
- [x] Roll Back
- Coordinate rollback with the `psq-payments-api` change — rolling back only one side will 401 (if API auth-enforced without this header) or silently mis-route Google Pay tokenization (if this header ships but the backend still returns static BasisTheory config).

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change