### PR TITLE
chore: reuse configured PublicSquare instance in Google Pay button widgets

### DIFF
--- a/js-sdk/src/googlePay/GooglePay.ts
+++ b/js-sdk/src/googlePay/GooglePay.ts
@@ -22,14 +22,17 @@ export class PublicSquareGooglePay {
 
   public renderButton(container: HTMLElement, options: GooglePayButtonWidgetOptions) {
     const validatedInput = validateGooglePayButtonWidgetOptions(options);
-    const widget = new GooglePayButtonWidget({
-      ...transformGooglePayButtonWidgetOptions(validatedInput),
-      onPaymentDataLoaded: (paymentData) => {
-        if (typeof options.onPaymentDataLoaded === 'function') {
-          options.onPaymentDataLoaded(paymentData);
-        }
+    const widget = new GooglePayButtonWidget(
+      {
+        ...transformGooglePayButtonWidgetOptions(validatedInput),
+        onPaymentDataLoaded: (paymentData) => {
+          if (typeof options.onPaymentDataLoaded === 'function') {
+            options.onPaymentDataLoaded(paymentData);
+          }
+        },
       },
-    });
+      this._publicSquare,
+    );
     widget.render(container);
     return widget;
   }

--- a/js-sdk/src/googlePay/GooglePayButtonWidget.ts
+++ b/js-sdk/src/googlePay/GooglePayButtonWidget.ts
@@ -1,21 +1,18 @@
 import { PublicSquare } from '@/PublicSquare';
-import type {
-  GooglePayButtonWidgetOptions,
-  GooglePayConfiguration,
-  PublicSquareInitOptions,
-} from '@/types';
+import type { GooglePayButtonWidgetOptions, GooglePayConfiguration } from '@/types';
 
 export class GooglePayButtonWidget {
   private options: GooglePayButtonWidgetOptions;
   private containerRef: HTMLElement | null;
   private paymentsClient: any;
-  private publicSquare = new PublicSquare();
+  private publicSquare: PublicSquare;
   private baseRequest = {
     apiVersion: 2,
     apiVersionMinor: 0,
   };
 
-  constructor(options: GooglePayButtonWidgetOptions) {
+  constructor(options: GooglePayButtonWidgetOptions, publicSquare: PublicSquare) {
+    this.publicSquare = publicSquare;
     this.options = {
       id: options.id,
       environment: options.environment,
@@ -130,9 +127,6 @@ export class GooglePayButtonWidget {
   }
 
   async setupGooglePayConfiguration(): Promise<GooglePayConfiguration> {
-    const apiKey = process.env.NEXT_PUBLIC_PUBLICSQUARE_KEY!;
-    let options: PublicSquareInitOptions = {};
-    await this.publicSquare.init(apiKey, options);
     try {
       const config = await this.publicSquare.googlePay.getGooglePayConfiguration();
       return config[this.options.environment];

--- a/js-sdk/src/googlePay/GooglePayButtonWidget.ts
+++ b/js-sdk/src/googlePay/GooglePayButtonWidget.ts
@@ -128,7 +128,10 @@ export class GooglePayButtonWidget {
 
   async setupGooglePayConfiguration(): Promise<GooglePayConfiguration> {
     try {
-      const config = await this.publicSquare.googlePay.getGooglePayConfiguration();
+      const config = (await this.publicSquare.googlePay.getGooglePayConfiguration()) as any;
+      if (config.error || !config[this.options.environment]) {
+        throw new Error('Failed to retrieve Google Pay configuration');
+      }
       return config[this.options.environment];
     } catch (error) {
       console.error('Error fetching Google Pay configuration:', error);

--- a/react-sdk/src/elements/GooglePayButtonElement.tsx
+++ b/react-sdk/src/elements/GooglePayButtonElement.tsx
@@ -52,7 +52,10 @@ const GooglePayButtonElement: React.FC<GooglePayButtonWidgetOptions> = (props) =
         throw new Error('PublicSquare SDK not initialized');
       }
       try {
-        const config = await psq.googlePay.getGooglePayConfiguration();
+        const config = (await psq.googlePay.getGooglePayConfiguration()) as any;
+        if (config.error || !config[environment]) {
+          throw new Error('Failed to retrieve Google Pay configuration');
+        }
         return config[environment];
       } catch (error) {
         console.error('Error fetching Google Pay configuration:', error);

--- a/react-sdk/src/elements/GooglePayButtonElement.tsx
+++ b/react-sdk/src/elements/GooglePayButtonElement.tsx
@@ -1,11 +1,10 @@
 import React, { useEffect, useRef } from 'react';
-import { PublicSquare } from '@publicsquare/elements-js/PublicSquare';
-import { PublicSquareInitOptions } from '../types';
 import {
   GooglePayConfiguration,
   GooglePayButtonWidgetOptions,
 } from '@publicsquare/elements-js/types';
 import { validateGooglePayButtonWidgetOptions } from '@publicsquare/elements-js/validators';
+import { usePublicSquare } from '../core/PublicSquareProvider';
 
 const GooglePayButtonElement: React.FC<GooglePayButtonWidgetOptions> = (props) => {
   const { validated } = validateGooglePayButtonWidgetOptions(props);
@@ -26,7 +25,11 @@ const GooglePayButtonElement: React.FC<GooglePayButtonWidgetOptions> = (props) =
     onPaymentDataLoaded,
   } = validated;
   const containerRef = useRef<HTMLDivElement>(null);
-  let publicSquare = new PublicSquare();
+  const { publicsquare } = usePublicSquare();
+  const publicSquareRef = useRef(publicsquare);
+  useEffect(() => {
+    publicSquareRef.current = publicsquare;
+  }, [publicsquare]);
 
   useEffect(() => {
     let paymentsClient: any;
@@ -44,11 +47,12 @@ const GooglePayButtonElement: React.FC<GooglePayButtonWidgetOptions> = (props) =
     };
 
     async function setupGooglePayConfiguration(): Promise<GooglePayConfiguration> {
-      const apiKey = process.env.NEXT_PUBLIC_PUBLICSQUARE_KEY!;
-      let options: PublicSquareInitOptions = {};
-      await publicSquare.init(apiKey, options);
+      const psq = publicSquareRef.current;
+      if (!psq) {
+        throw new Error('PublicSquare SDK not initialized');
+      }
       try {
-        const config = await publicSquare.googlePay.getGooglePayConfiguration();
+        const config = await psq.googlePay.getGooglePayConfiguration();
         return config[environment];
       } catch (error) {
         console.error('Error fetching Google Pay configuration:', error);

--- a/react-sdk/yarn.lock
+++ b/react-sdk/yarn.lock
@@ -1443,10 +1443,10 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.2.9.tgz#d229a7b7f9dac167a156992ef23c7f023653f53b"
   integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
 
-"@publicsquare/elements-js@1.13.1":
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/@publicsquare/elements-js/-/elements-js-1.13.1.tgz#047c7955e17c0c5cd85ea919d5467db27117a941"
-  integrity sha512-1H0Zx0U6WUhPILeRO4KDG2TW5iu5NBpH1IH0Q2DV2nqU4r616nx8+ody7/fHYC3xY0ih/1ctWeBi0GZTntjLSw==
+"@publicsquare/elements-js@1.14.0":
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/@publicsquare/elements-js/-/elements-js-1.14.0.tgz#f005d54b6d95baec5bfea64cdfdf7702e1bcc76b"
+  integrity sha512-is634JMYHuz9mOwVpJI/rhtcGR/3LCeSm/HivgXF9RBvXRMLiyDc49tCUEGl/DLu0+E8m/18DF5GI/7k/kwSeg==
   dependencies:
     "@basis-theory/basis-theory-js" "^4.30.0"
     "@basis-theory/web-threeds" "^2.1.2"


### PR DESCRIPTION
## Description

- `GooglePayButtonWidget` (js-sdk) and `GooglePayButtonElement` (react-sdk) each created their own throwaway `PublicSquare` instance on click, hardcoded to `process.env.NEXT_PUBLIC_PUBLICSQUARE_KEY` and default (production) URLs — ignoring whatever `apiKey`/environment the consuming app configured on its own `PublicSquare` instance.
- Practical effect: clicking the Google Pay button always fetched the gateway config (`gateway`, `gatewayMerchantId`) from **production**, regardless of the app's configured environment. For any non-production-gateway merchant (verified with a Moov-backed staging account), Google Pay then tokenizes against the wrong gateway, and the backend rejects the resulting token.
- Fix: `js-sdk`'s `PublicSquareGooglePay.renderButton()` now passes its own `PublicSquare` instance into `GooglePayButtonWidget`'s constructor, which reuses it instead of creating a new one. `react-sdk`'s `GooglePayButtonElement` now reads the instance via the existing `usePublicSquare()` / `PublicSquareProvider` context, matching the pattern already used by other elements in the SDK.
- Shipped as `chore:` (not `fix:`) intentionally — holding off the semantic-release version bump for this change.

## Testing required outside of automated testing?

- [x] Verified via `make build`-equivalent (yarn build in js-sdk/react-sdk, linked into example-app) against staging with a real Moov-backed API key: confirmed via staging logs that the `getGooglePayConfiguration` request now returns `gateway: moov` (matching the account) instead of `gateway: basistheory` (production default).
- [ ] A separate, pre-existing Moov integration issue (`payment-methods/google-pay` returns 500, Moov's `/google-pay/tokens` responds `"request contained invalid data"`) was found during testing — confirmed via 90 days of staging logs to predate this change and affect every historical attempt. Out of scope for this PR; flagged separately for the payments-api/Moov integration.

### Screenshots (if appropriate):

- [x] Not Applicable

## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change

🤖 Generated with [Claude Code](https://claude.com/claude-code)