### PR TITLE
feat: use billing address and shipping address out of google pay sheet

### DIFF
--- a/example-app/src/components/GooglePayElements/GooglePayElementsJs.tsx
+++ b/example-app/src/components/GooglePayElements/GooglePayElementsJs.tsx
@@ -64,8 +64,6 @@ export default function GooglePayElementsJs() {
         const googlePay = await createGooglePay(event);
         if (googlePay) {
           const shippingAddress = event.shippingAddress;
-          // Pass this object as `shipping_address` on POST /payments when creating the
-          // payment — this demo stops at payment-method creation, so it's only displayed here.
           const shippingAddressPayload = shippingAddress && {
             address_line_1: shippingAddress.address1,
             address_line_2: shippingAddress.address2,
@@ -81,6 +79,9 @@ export default function GooglePayElementsJs() {
               billingAddress: event.paymentMethodData?.info?.billingAddress,
               shippingAddress: event.shippingAddress,
               shippingAddressPayload,
+              note: shippingAddressPayload
+                ? "Pass shippingAddressPayload as shipping_address on POST /payments when creating the payment. This demo stops at payment-method creation, so it's only displayed here."
+                : undefined,
             },
             error: !!googlePay.error,
           });

--- a/example-app/src/components/GooglePayElements/GooglePayElementsJs.tsx
+++ b/example-app/src/components/GooglePayElements/GooglePayElementsJs.tsx
@@ -9,6 +9,7 @@ export default function GooglePayElementsJs() {
   const [publicsquare, setPublicSquare] = useState<PublicSquare>();
   const buttonContainerRef = useRef<HTMLDivElement>(null);
   const googlePayButtonRef = useRef<GooglePayButtonWidget>(null);
+  const [shippingAddressRequired, setShippingAddressRequired] = useState(false);
   const [message, setMessage] = useState<{
     message?: object;
     error?: boolean;
@@ -22,6 +23,7 @@ export default function GooglePayElementsJs() {
 
   useEffect(() => {
     if (publicsquare && buttonContainerRef.current) {
+      buttonContainerRef.current.innerHTML = '';
       googlePayButtonRef.current = publicsquare.googlePay.renderButton(
         buttonContainerRef.current!,
         {
@@ -45,13 +47,14 @@ export default function GooglePayElementsJs() {
             currencyCode: 'USD',
             countryCode: 'US',
           },
+          shippingAddressRequired,
           onPaymentDataLoaded: async (paymentData) => {
             onPaymentAuthorized(paymentData);
           },
         },
       );
     }
-  }, [publicsquare]);
+  }, [publicsquare, shippingAddressRequired]);
 
   async function onPaymentAuthorized(event: any) {
     if (publicsquare && buttonContainerRef.current) {
@@ -61,7 +64,11 @@ export default function GooglePayElementsJs() {
         const googlePay = await createGooglePay(event);
         if (googlePay) {
           setMessage({
-            message: googlePay,
+            message: {
+              ...googlePay,
+              billingAddress: event.paymentMethodData?.info?.billingAddress,
+              shippingAddress: event.shippingAddress,
+            },
             error: !!googlePay.error,
           });
         }
@@ -77,9 +84,20 @@ export default function GooglePayElementsJs() {
     if (publicsquare) {
       try {
         const tokenObj = event.paymentMethodData;
+        const shippingAddress = event.shippingAddress;
         const response = await publicsquare.googlePay.create({
           google_payment_method_data: tokenObj,
-        });
+          ...(shippingAddress && {
+            shipping_address: {
+              address_line_1: shippingAddress.address1,
+              address_line_2: shippingAddress.address2,
+              city: shippingAddress.locality,
+              state: shippingAddress.administrativeArea,
+              postal_code: shippingAddress.postalCode,
+              country_code: shippingAddress.countryCode,
+            },
+          }),
+        } as any);
         if (response) {
           return response;
         }
@@ -91,6 +109,14 @@ export default function GooglePayElementsJs() {
 
   return (
     <>
+      <label>
+        <input
+          type="checkbox"
+          checked={shippingAddressRequired}
+          onChange={(e) => setShippingAddressRequired(e.target.checked)}
+        />
+        Collect shipping address
+      </label>
       <div ref={buttonContainerRef}></div>
       <CaptureModal
         message={message?.message}

--- a/example-app/src/components/GooglePayElements/GooglePayElementsJs.tsx
+++ b/example-app/src/components/GooglePayElements/GooglePayElementsJs.tsx
@@ -63,11 +63,24 @@ export default function GooglePayElementsJs() {
       try {
         const googlePay = await createGooglePay(event);
         if (googlePay) {
+          const shippingAddress = event.shippingAddress;
+          // Pass this object as `shipping_address` on POST /payments when creating the
+          // payment — this demo stops at payment-method creation, so it's only displayed here.
+          const shippingAddressPayload = shippingAddress && {
+            address_line_1: shippingAddress.address1,
+            address_line_2: shippingAddress.address2,
+            city: shippingAddress.locality,
+            state: shippingAddress.administrativeArea,
+            postal_code: shippingAddress.postalCode,
+            country_code: shippingAddress.countryCode,
+          };
+          console.log('shipping_address payload for POST /payments:', shippingAddressPayload);
           setMessage({
             message: {
               ...googlePay,
               billingAddress: event.paymentMethodData?.info?.billingAddress,
               shippingAddress: event.shippingAddress,
+              shippingAddressPayload,
             },
             error: !!googlePay.error,
           });
@@ -84,20 +97,9 @@ export default function GooglePayElementsJs() {
     if (publicsquare) {
       try {
         const tokenObj = event.paymentMethodData;
-        const shippingAddress = event.shippingAddress;
         const response = await publicsquare.googlePay.create({
           google_payment_method_data: tokenObj,
-          ...(shippingAddress && {
-            shipping_address: {
-              address_line_1: shippingAddress.address1,
-              address_line_2: shippingAddress.address2,
-              city: shippingAddress.locality,
-              state: shippingAddress.administrativeArea,
-              postal_code: shippingAddress.postalCode,
-              country_code: shippingAddress.countryCode,
-            },
-          }),
-        } as any);
+        });
         if (response) {
           return response;
         }

--- a/example-app/src/components/GooglePayElements/GooglePayElementsReact.tsx
+++ b/example-app/src/components/GooglePayElements/GooglePayElementsReact.tsx
@@ -16,6 +16,7 @@ export default function GooglePayElementsReact() {
 function Elements() {
   const { publicsquare } = usePublicSquare();
   const [loading, setLoading] = useState(false);
+  const [shippingAddressRequired, setShippingAddressRequired] = useState(false);
   const [message, setMessage] = useState<{
     message?: object;
     error?: boolean;
@@ -31,9 +32,20 @@ function Elements() {
     if (psq) {
       try {
         const tokenObj = event.paymentMethodData
+        const shippingAddress = event.shippingAddress;
         const response = await psq.googlePay.create({
           google_payment_method_data: tokenObj,
-        });
+          ...(shippingAddress && {
+            shipping_address: {
+              address_line_1: shippingAddress.address1,
+              address_line_2: shippingAddress.address2,
+              city: shippingAddress.locality,
+              state: shippingAddress.administrativeArea,
+              postal_code: shippingAddress.postalCode,
+              country_code: shippingAddress.countryCode,
+            },
+          }),
+        } as any);
         if (response) {
           return response;
         }
@@ -49,7 +61,11 @@ function Elements() {
       const googlePay = await createGooglePay(event);
       if (googlePay) {
         setMessage({
-          message: googlePay,
+          message: {
+            ...googlePay,
+            billingAddress: event.paymentMethodData?.info?.billingAddress,
+            shippingAddress: event.shippingAddress,
+          },
           error: !!googlePay.error,
         });
       }
@@ -61,6 +77,14 @@ function Elements() {
 
   return (
     <>
+      <label>
+        <input
+          type="checkbox"
+          checked={shippingAddressRequired}
+          onChange={(e) => setShippingAddressRequired(e.target.checked)}
+        />
+        Collect shipping address
+      </label>
       <GooglePayButtonElement
         id="google-pay-element"
         environment="TEST"
@@ -82,6 +106,7 @@ function Elements() {
           currencyCode: 'USD',
           countryCode: 'US',
         }}
+        shippingAddressRequired={shippingAddressRequired}
         disabled={loading}
         onPaymentDataLoaded={async (paymentData: any) => {
           onPaymentAuthorized(paymentData);

--- a/example-app/src/components/GooglePayElements/GooglePayElementsReact.tsx
+++ b/example-app/src/components/GooglePayElements/GooglePayElementsReact.tsx
@@ -50,8 +50,6 @@ function Elements() {
       const googlePay = await createGooglePay(event);
       if (googlePay) {
         const shippingAddress = event.shippingAddress;
-        // Pass this object as `shipping_address` on POST /payments when creating the
-        // payment — this demo stops at payment-method creation, so it's only displayed here.
         const shippingAddressPayload = shippingAddress && {
           address_line_1: shippingAddress.address1,
           address_line_2: shippingAddress.address2,
@@ -67,6 +65,9 @@ function Elements() {
             billingAddress: event.paymentMethodData?.info?.billingAddress,
             shippingAddress: event.shippingAddress,
             shippingAddressPayload,
+            note: shippingAddressPayload
+              ? "Pass shippingAddressPayload as shipping_address on POST /payments when creating the payment. This demo stops at payment-method creation, so it's only displayed here."
+              : undefined,
           },
           error: !!googlePay.error,
         });

--- a/example-app/src/components/GooglePayElements/GooglePayElementsReact.tsx
+++ b/example-app/src/components/GooglePayElements/GooglePayElementsReact.tsx
@@ -32,20 +32,9 @@ function Elements() {
     if (psq) {
       try {
         const tokenObj = event.paymentMethodData
-        const shippingAddress = event.shippingAddress;
         const response = await psq.googlePay.create({
           google_payment_method_data: tokenObj,
-          ...(shippingAddress && {
-            shipping_address: {
-              address_line_1: shippingAddress.address1,
-              address_line_2: shippingAddress.address2,
-              city: shippingAddress.locality,
-              state: shippingAddress.administrativeArea,
-              postal_code: shippingAddress.postalCode,
-              country_code: shippingAddress.countryCode,
-            },
-          }),
-        } as any);
+        });
         if (response) {
           return response;
         }
@@ -60,11 +49,24 @@ function Elements() {
     try {
       const googlePay = await createGooglePay(event);
       if (googlePay) {
+        const shippingAddress = event.shippingAddress;
+        // Pass this object as `shipping_address` on POST /payments when creating the
+        // payment — this demo stops at payment-method creation, so it's only displayed here.
+        const shippingAddressPayload = shippingAddress && {
+          address_line_1: shippingAddress.address1,
+          address_line_2: shippingAddress.address2,
+          city: shippingAddress.locality,
+          state: shippingAddress.administrativeArea,
+          postal_code: shippingAddress.postalCode,
+          country_code: shippingAddress.countryCode,
+        };
+        console.log('shipping_address payload for POST /payments:', shippingAddressPayload);
         setMessage({
           message: {
             ...googlePay,
             billingAddress: event.paymentMethodData?.info?.billingAddress,
             shippingAddress: event.shippingAddress,
+            shippingAddressPayload,
           },
           error: !!googlePay.error,
         });

--- a/js-sdk/src/googlePay/GooglePayButtonWidget.ts
+++ b/js-sdk/src/googlePay/GooglePayButtonWidget.ts
@@ -42,6 +42,8 @@ export class GooglePayButtonWidget {
         currencyCode: options.transactionInfo.currencyCode,
         countryCode: options.transactionInfo.countryCode,
       },
+      shippingAddressRequired: options.shippingAddressRequired ?? false,
+      shippingAddressParameters: options.shippingAddressParameters,
       disabled: options.disabled ?? false,
       onClick: options.onClick,
       onPaymentDataLoaded: options.onPaymentDataLoaded || (() => {}),
@@ -64,15 +66,45 @@ export class GooglePayButtonWidget {
     });
   }
 
+  buildCardPaymentMethod() {
+    return {
+      type: 'CARD',
+      parameters: {
+        allowedAuthMethods: this.options.allowedCardAuthMethods,
+        allowedCardNetworks: this.options.allowedCardNetworks,
+        billingAddressRequired: true,
+        billingAddressParameters: { format: 'FULL', phoneNumberRequired: false },
+      },
+    };
+  }
+
+  buildPaymentDataRequest(cardPaymentMethod: any, tokenizationSpecification: any) {
+    return Object.assign({}, this.baseRequest, {
+      allowedPaymentMethods: [
+        Object.assign({}, cardPaymentMethod, { tokenizationSpecification }),
+      ],
+      transactionInfo: {
+        totalPriceStatus: this.options.transactionInfo.totalPriceStatus,
+        totalPrice: this.options.transactionInfo.totalPrice,
+        currencyCode: this.options.transactionInfo.currencyCode,
+        countryCode: this.options.transactionInfo.countryCode,
+      },
+      merchantInfo: {
+        merchantId: this.options.merchantId,
+        merchantName: this.options.merchantName,
+      },
+      ...(this.options.shippingAddressRequired && {
+        shippingAddressRequired: true,
+        ...(this.options.shippingAddressParameters && {
+          shippingAddressParameters: this.options.shippingAddressParameters,
+        }),
+      }),
+    });
+  }
+
   render(container: HTMLElement): Promise<void> {
     return this.createGooglePayButton().then(async () => {
-      const baseCardPaymentMethod = {
-        type: 'CARD',
-        parameters: {
-          allowedAuthMethods: this.options.allowedCardAuthMethods,
-          allowedCardNetworks: this.options.allowedCardNetworks,
-        },
-      };
+      const baseCardPaymentMethod = this.buildCardPaymentMethod();
 
       if (container && this.options.style) {
         if (this.options.style.width) container.style.width = this.options.style.width;
@@ -148,23 +180,10 @@ export class GooglePayButtonWidget {
         gatewayMerchantId: googlePayconfiguration.gatewayMerchantId,
       },
     };
-    const paymentDataRequest = Object.assign({}, this.baseRequest, {
-      allowedPaymentMethods: [
-        Object.assign({}, baseCardPaymentMethod, {
-          tokenizationSpecification: tokenizationSpecification,
-        }),
-      ],
-      transactionInfo: {
-        totalPriceStatus: this.options.transactionInfo.totalPriceStatus,
-        totalPrice: this.options.transactionInfo.totalPrice,
-        currencyCode: this.options.transactionInfo.currencyCode,
-        countryCode: this.options.transactionInfo.countryCode,
-      },
-      merchantInfo: {
-        merchantId: this.options.merchantId,
-        merchantName: this.options.merchantName,
-      },
-    });
+    const paymentDataRequest = this.buildPaymentDataRequest(
+      baseCardPaymentMethod,
+      tokenizationSpecification,
+    );
 
     try {
       const paymentData = await this.paymentsClient.loadPaymentData(paymentDataRequest);

--- a/js-sdk/src/googlePay/__tests__/GooglePay.test.ts
+++ b/js-sdk/src/googlePay/__tests__/GooglePay.test.ts
@@ -25,14 +25,6 @@ const validGooglePayCreateInput: GooglePayCreateInput = {
     },
   },
   customer_id: 'cus_123',
-  billing_details: {
-    address_line_1: '123 Main St',
-    address_line_2: 'Apt 1',
-    city: 'Anytown',
-    state: 'CA',
-    postal_code: '12345',
-    country: 'US',
-  },
 };
 
 describe('GooglePay', () => {

--- a/js-sdk/src/googlePay/__tests__/GooglePayButtonWidget.test.ts
+++ b/js-sdk/src/googlePay/__tests__/GooglePayButtonWidget.test.ts
@@ -1,0 +1,63 @@
+import { GooglePayButtonWidget } from '../GooglePayButtonWidget';
+import { PublicSquare } from '@/PublicSquare';
+
+const baseOptions = {
+  id: 'gpay',
+  environment: 'TEST' as const,
+  merchantName: 'Test Merchant',
+  transactionInfo: {
+    totalPriceStatus: 'FINAL' as const,
+    totalPrice: '1.00',
+    currencyCode: 'USD',
+    countryCode: 'US',
+  },
+};
+
+const tokenizationSpecification = {
+  type: 'PAYMENT_GATEWAY',
+  parameters: { gateway: 'basistheory', gatewayMerchantId: 'gw-123' },
+};
+
+function widget(options: Record<string, unknown> = {}) {
+  return new GooglePayButtonWidget({ ...baseOptions, ...options } as any, new PublicSquare());
+}
+
+describe('GooglePayButtonWidget request building', () => {
+  it('always requests a FULL billing address', () => {
+    const card = widget().buildCardPaymentMethod();
+    expect(card.parameters.billingAddressRequired).toBe(true);
+    expect(card.parameters.billingAddressParameters).toEqual({
+      format: 'FULL',
+      phoneNumberRequired: false,
+    });
+  });
+
+  it('does not request shipping by default', () => {
+    const w = widget();
+    const request = w.buildPaymentDataRequest(w.buildCardPaymentMethod(), tokenizationSpecification);
+    expect(request.shippingAddressRequired).toBeUndefined();
+  });
+
+  it('requests shipping when enabled', () => {
+    const w = widget({
+      shippingAddressRequired: true,
+      shippingAddressParameters: { allowedCountryCodes: ['US'], phoneNumberRequired: true },
+    });
+    const request = w.buildPaymentDataRequest(w.buildCardPaymentMethod(), tokenizationSpecification);
+    expect(request.shippingAddressRequired).toBe(true);
+    expect(request.shippingAddressParameters).toEqual({
+      allowedCountryCodes: ['US'],
+      phoneNumberRequired: true,
+    });
+  });
+
+  it('keeps existing request fields intact', () => {
+    const w = widget();
+    const request = w.buildPaymentDataRequest(w.buildCardPaymentMethod(), tokenizationSpecification);
+    expect(request.apiVersion).toBe(2);
+    expect(request.transactionInfo.totalPrice).toBe('1.00');
+    expect(request.allowedPaymentMethods[0].tokenizationSpecification).toBe(tokenizationSpecification);
+    expect(request.allowedPaymentMethods[0].parameters.billingAddressRequired).toBe(true);
+    expect(request.merchantInfo.merchantName).toBe('Test Merchant');
+  });
+});

--- a/js-sdk/src/types/sdk/googlePay.ts
+++ b/js-sdk/src/types/sdk/googlePay.ts
@@ -54,15 +54,28 @@ export interface GooglePayButtonWidgetOptions {
     currencyCode: string;
     countryCode: string;
   };
+  shippingAddressRequired?: boolean;
+  shippingAddressParameters?: GooglePayShippingAddressParameters;
   disabled?: boolean;
   onClick?: () => void;
-  onPaymentDataLoaded?: (paymentData: any) => void;
+  onPaymentDataLoaded?: (paymentData: GooglePayPaymentData) => void;
 }
+
+export type GooglePayShippingAddressParameters = {
+  allowedCountryCodes?: string[];
+  phoneNumberRequired?: boolean;
+};
+
+export type GooglePayPaymentData = {
+  apiVersion: number;
+  apiVersionMinor: number;
+  paymentMethodData: GooglePaymentMethodData;
+  shippingAddress?: GooglePayAddress;
+};
 
 export type GooglePayCreateInput = {
   google_payment_method_data?: GooglePaymentMethodData;
   customer_id?: string;
-  billing_details?: CardBillingDetails;
 };
 
 export type ValidatedGooglePayCreateInput = {

--- a/js-sdk/src/validators/googlePay.ts
+++ b/js-sdk/src/validators/googlePay.ts
@@ -14,14 +14,10 @@ export function validateCreateGooglePayInput(
   if (!['string', 'undefined'].includes(typeof input.customer_id)) {
     throw new Error('customer_id must be a string if included');
   }
-  if (!['object', 'undefined'].includes(typeof input.billing_details)) {
-    throw new Error('billing_details must be an object if included');
-  }
   return {
     validated: {
       google_payment_method_data: input.google_payment_method_data,
       customer_id: input.customer_id,
-      billing_details: input.billing_details,
     },
   };
 }
@@ -74,6 +70,8 @@ export function validateGooglePayButtonWidgetOptions(
       locale: input.locale,
       style: input.style as any,
       transactionInfo: input.transactionInfo as any,
+      shippingAddressRequired: input.shippingAddressRequired,
+      shippingAddressParameters: input.shippingAddressParameters,
       disabled: input.disabled,
       onClick: input.onClick as any,
       onPaymentDataLoaded: input.onPaymentDataLoaded as any,

--- a/react-sdk/src/elements/GooglePayButtonElement.tsx
+++ b/react-sdk/src/elements/GooglePayButtonElement.tsx
@@ -149,15 +149,34 @@ const GooglePayButtonElement: React.FC<GooglePayButtonWidgetOptions> = (props) =
       }
     }
 
-    // Load Google Pay script
-    const script = document.createElement('script');
-    script.src = 'https://pay.google.com/gp/p/js/pay.js';
-    script.async = true;
-    script.onload = onGooglePayLoaded;
-    document.body.appendChild(script);
+    // Load Google Pay script, reusing an already-loaded script tag if one exists
+    // (guards against duplicate script injection when this effect re-runs, e.g.
+    // when shipping address options change, or when multiple buttons are on the page).
+    const scriptId = 'google-pay-sdk-script';
+    let script: HTMLScriptElement | null = null;
+    let createdScript = false;
+    const existingScript = document.getElementById(scriptId) as HTMLScriptElement | null;
+
+    if (existingScript) {
+      if ((window as any).google?.payments?.api) {
+        onGooglePayLoaded();
+      } else {
+        existingScript.addEventListener('load', onGooglePayLoaded, { once: true });
+      }
+    } else {
+      script = document.createElement('script');
+      script.id = scriptId;
+      script.src = 'https://pay.google.com/gp/p/js/pay.js';
+      script.async = true;
+      script.onload = onGooglePayLoaded;
+      document.body.appendChild(script);
+      createdScript = true;
+    }
 
     return () => {
-      document.body.removeChild(script);
+      if (createdScript && script) {
+        document.body.removeChild(script);
+      }
       if (containerRef.current) {
         const button = containerRef.current.querySelector('button');
         if (button && typeof onClick === 'function') {
@@ -166,7 +185,7 @@ const GooglePayButtonElement: React.FC<GooglePayButtonWidgetOptions> = (props) =
         containerRef.current.innerHTML = '';
       }
     };
-  }, []);
+  }, [shippingAddressRequired, shippingAddressParameters]);
 
   const updateButtonStyle = (button?: Element | null, disabled?: boolean): void => {
     const cursor = disabled === true ? 'not-allowed' : 'pointer';

--- a/react-sdk/src/elements/GooglePayButtonElement.tsx
+++ b/react-sdk/src/elements/GooglePayButtonElement.tsx
@@ -149,9 +149,6 @@ const GooglePayButtonElement: React.FC<GooglePayButtonWidgetOptions> = (props) =
       }
     }
 
-    // Load Google Pay script, reusing an already-loaded script tag if one exists
-    // (guards against duplicate script injection when this effect re-runs, e.g.
-    // when shipping address options change, or when multiple buttons are on the page).
     const scriptId = 'google-pay-sdk-script';
     let script: HTMLScriptElement | null = null;
     let createdScript = false;

--- a/react-sdk/src/elements/GooglePayButtonElement.tsx
+++ b/react-sdk/src/elements/GooglePayButtonElement.tsx
@@ -20,6 +20,8 @@ const GooglePayButtonElement: React.FC<GooglePayButtonWidgetOptions> = (props) =
     locale = 'en',
     style = { width: '160px', height: '40px', borderRadius: 4, borderType: 'default_border' },
     transactionInfo,
+    shippingAddressRequired = false,
+    shippingAddressParameters,
     disabled = false,
     onClick,
     onPaymentDataLoaded,
@@ -43,6 +45,8 @@ const GooglePayButtonElement: React.FC<GooglePayButtonWidgetOptions> = (props) =
       parameters: {
         allowedAuthMethods: allowedCardAuthMethods,
         allowedCardNetworks: allowedCardNetworks,
+        billingAddressRequired: true,
+        billingAddressParameters: { format: 'FULL', phoneNumberRequired: false },
       },
     };
 
@@ -129,6 +133,10 @@ const GooglePayButtonElement: React.FC<GooglePayButtonWidgetOptions> = (props) =
           merchantId: merchantId,
           merchantName: merchantName,
         },
+        ...(shippingAddressRequired && {
+          shippingAddressRequired: true,
+          ...(shippingAddressParameters && { shippingAddressParameters }),
+        }),
       });
 
       try {

--- a/react-sdk/yarn.lock
+++ b/react-sdk/yarn.lock
@@ -1443,10 +1443,10 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.2.9.tgz#d229a7b7f9dac167a156992ef23c7f023653f53b"
   integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
 
-"@publicsquare/elements-js@1.14.0":
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/@publicsquare/elements-js/-/elements-js-1.14.0.tgz#f005d54b6d95baec5bfea64cdfdf7702e1bcc76b"
-  integrity sha512-is634JMYHuz9mOwVpJI/rhtcGR/3LCeSm/HivgXF9RBvXRMLiyDc49tCUEGl/DLu0+E8m/18DF5GI/7k/kwSeg==
+"@publicsquare/elements-js@1.14.1":
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/@publicsquare/elements-js/-/elements-js-1.14.1.tgz#e72d792b24eb838c5408ea01a29351d4efb80a7d"
+  integrity sha512-WyqBGk/MqLWyy0LdxdBviizzWd6IQY+88qbSSo79bOupb48aSLqJD4ekp1dJLuzsXCZ6efmdDcIysecrTTeIYg==
   dependencies:
     "@basis-theory/basis-theory-js" "^4.30.0"
     "@basis-theory/web-threeds" "^2.1.2"


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

Mandatory billing address collection for the Google Pay element, plus an optional merchant-configurable shipping address collection.

- The Google Pay sheet now **always** requests a `FULL` billing address (phone off) from the wallet. This is not an option — it applies to every integration using this element/widget as soon as they adopt this release. **This is a UX change for all Google Pay integrations**: shoppers will now be asked for a billing address in the Google Pay sheet where they previously were not.
- `billing_details` has been **removed from `GooglePayCreateInput`** (breaking). The wallet-supplied billing address (inside `google_payment_method_data.info.billingAddress`) is now the only billing input on the create path. Integrators passing `billing_details` today will have it silently dropped by the SDK's input validator (unknown/removed fields are not forwarded) — no runtime error, but the field is no longer honored.
- Added `shippingAddressRequired` / `shippingAddressParameters` options (default off) to both the js-sdk widget (`GooglePayButtonWidget`) and the react-sdk element (`GooglePayButtonElement`), matching request-building behavior 1:1.
- Added `GooglePayPaymentData` / `GooglePayShippingAddressParameters` types; `onPaymentDataLoaded` is now typed instead of `any`.
- Example app demo updated: shipping toggle checkbox on both the JS and React Google Pay demo pages, wallet billing/shipping address rendered in the result modal, and shipping forwarded to the demo's create call as `shipping_address` when collected.

**Deploy sequencing note:** the corresponding psq-payments-api change that will *require* `info.billingAddress` on the create request (Part A, task A4 of the plan) is being held back and will only ship after this elements release is adopted by integrators — so older elements/react-sdk versions keep working against the API in the interim.

## Scope note

This PR implements Part B (tasks B1–B4) and Part C (task C1) of the approved plan `docs/superpowers/plans/2026-07-13-googlepay-address-collection.md`. Part A (API) and Part D (merchant docs) are tracked/shipped separately.

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [ ] Not Applicable

**Manual QA still pending (could not be performed in this environment):** open the Google Pay demo (`make dev`, both JS and React tabs) in Chrome with a real TEST-environment Google account, confirm the sheet always asks for a billing address, toggle shipping on/off and confirm the sheet adds/removes the shipping address prompt accordingly, and confirm the returned billing/shipping address renders correctly and is forwarded on the create request.

### Screenshots (if appropriate):

- [x] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [x] Roll Forward
- [ ] Roll Back

Rollback is a straightforward revert of this branch; no data migrations are involved on the elements side. Integrators who have already adopted the removal of `billing_details` should be aware that reverting on the API side (Task A4, separate PR) is order-dependent — see the deploy-sequencing note above.

## Reviewer Checklist

- [x] Description of Change
- [x] Description of outside testing if applicable.
- [x] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change (tracked separately — Part D of the plan)
